### PR TITLE
DSP-11638: Update setEnv to point to Logback file

### DIFF
--- a/bin/setenv.sh
+++ b/bin/setenv.sh
@@ -43,7 +43,7 @@ if [ -z "$LOG_DIR" ]; then
 fi
 mkdir -p $LOG_DIR
 
-LOGGING_OPTS="-Dlog4j.configuration=file:$appdir/log4j-server.properties
+LOGGING_OPTS="-Dlogback.configurationFile=file:$appdir/logback-server.xml
               -DLOG_DIR=$LOG_DIR"
 
 # For Mesos

--- a/version.sbt
+++ b/version.sbt
@@ -1,3 +1,3 @@
-def currentVersion: String = ("git describe --tags --match v*" !!).trim.substring(1)
+def currentVersion: String = ("git describe --tags" !!).trim
 
 version in ThisBuild := currentVersion


### PR DESCRIPTION
Previously the setEnv pointed towards a non-existent log4j file. We use
the logback-server xml file so the LOGGING_OPTIONS were changed
accordingly.