### PR TITLE
netty 4.1.13 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -265,6 +265,7 @@ lazy val commonSettings = Defaults.coreDefaultSettings ++ dirSettings ++ implici
   // For Building on Encrypted File Systems...
   scalacOptions ++= Seq("-Xmax-classfile-name", "128"),
   resolvers ++= Dependencies.repos,
+  credentials += Credentials(Path.userHome / ".sbt" / ".credentials"),
   libraryDependencies ++= apiDeps,
   parallelExecution in Test := false,
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),

--- a/project/Assembly.scala
+++ b/project/Assembly.scala
@@ -10,7 +10,9 @@ object Assembly {
     assemblyExcludedJars in assembly <<= (fullClasspath in assembly) map { _ filter { cp =>
       List("servlet-api", "guice-all", "junit", "uuid",
         "jetty", "jsp-api-2.0", "antlr", "avro", "slf4j-log4j", "log4j-1.2",
-        "scala-actors", "spark", "commons-cli", "stax-api", "mockito").exists(cp.data.getName.startsWith(_))
+        "scala-actors", "spark", "commons-cli", "stax-api", "mockito",
+        // we rely on whatever version DSE has:
+        "netty", "dse-java-driver").exists(cp.data.getName.startsWith(_))
     } },
     // We don't need the Scala library, Spark already includes it
     assembleArtifact in assemblyPackageScala := false,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,18 +28,16 @@ object Dependencies {
   )
 
   lazy val sparkDeps = Seq(
-    "org.apache.spark" %% "spark-core" % spark % "provided" excludeAll(excludeNettyIo, excludeQQ),
-    // Force netty version.  This avoids some Spark netty dependency problem.
-    "io.netty" % "netty-all" % netty
+    "com.datastax.spark" %% "spark-core" % spark % Provided excludeAll(excludeQQ)
   )
 
   lazy val sparkExtraDeps = Seq(
-    "org.apache.spark" %% "spark-mllib" % spark % Provided excludeAll(excludeNettyIo, excludeQQ),
-    "org.apache.spark" %% "spark-sql" % spark % Provided excludeAll(excludeNettyIo, excludeQQ),
-    "org.apache.spark" %% "spark-streaming" % spark % Provided excludeAll(excludeNettyIo, excludeQQ),
-    "org.apache.spark" %% "spark-hive" % spark % Provided excludeAll(
+    "com.datastax.spark" %% "spark-mllib" % spark % Provided excludeAll(excludeNettyIo, excludeQQ),
+    "com.datastax.spark" %% "spark-sql" % spark % Provided excludeAll(excludeNettyIo, excludeQQ),
+    "com.datastax.spark" %% "spark-streaming" % spark % Provided excludeAll(excludeNettyIo, excludeQQ),
+    "com.datastax.spark" %% "spark-hive" % spark % Provided excludeAll(
       excludeNettyIo, excludeQQ, excludeScalaTest
-      )
+    )
   )
 
   lazy val sparkExtraDepsTest = Seq(
@@ -60,8 +58,8 @@ object Dependencies {
   )
 
   lazy val cassandraDeps = Seq(
-    "com.datastax.cassandra" % "cassandra-driver-core" % cassandra,
-    "com.datastax.cassandra" % "cassandra-driver-mapping" % cassandra
+    "com.datastax.dse" % "dse-java-driver-core" % dseDriver % Provided excludeAll excludeNettyIo,
+    "com.datastax.dse" % "dse-java-driver-mapping" % dseDriver % Provided excludeAll excludeNettyIo
   )
 
   lazy val logbackDeps = Seq(
@@ -85,6 +83,7 @@ object Dependencies {
   lazy val apiDeps = sparkDeps ++ miscDeps :+ typeSafeConfigDeps :+ scalaTestDep
 
   val repos = Seq(
+    "datastax-release" at "http://datastax.artifactoryonline.com/datastax/datastax-releases-local",
     "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/",
     "sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/",
     "spray repo" at "http://repo.spray.io"

--- a/project/ExclusionRules.scala
+++ b/project/ExclusionRules.scala
@@ -5,7 +5,7 @@ object ExclusionRules {
   val excludeJackson = ExclusionRule(organization = "org.codehaus.jackson")
   val excludeScalaTest = ExclusionRule(organization = "org.scalatest")
   val excludeScala = ExclusionRule(organization = "org.scala-lang")
-  val excludeNettyIo = ExclusionRule(organization = "io.netty", artifact = "netty-all")
+  val excludeNettyIo = ExclusionRule(organization = "io.netty")
   val excludeAsm = ExclusionRule(organization = "asm")
   val excludeQQ = ExclusionRule(organization = "org.scalamacros")
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,10 +1,10 @@
 import scala.util.Properties.isJavaAtLeast
 
 object Versions {
-  lazy val spark = sys.env.getOrElse("SPARK_VERSION", "2.2.0")
+  lazy val spark = sys.env.getOrElse("SPARK_VERSION", "2.2.0.0-e9faedf")
 
   lazy val akka = "2.4.9"
-  lazy val cassandra = "3.2.0"
+  lazy val dseDriver = "1.4.0"
   lazy val cassandraUnit = "2.2.2.1"
   lazy val commons = "1.4"
   lazy val flyway = "3.2.1"
@@ -15,7 +15,6 @@ object Versions {
   lazy val logback = "1.0.7"
   lazy val mesos = sys.env.getOrElse("MESOS_VERSION", "1.0.0-2.0.89.ubuntu1404")
   lazy val metrics = "2.2.0"
-  lazy val netty = "4.0.44.Final"
   lazy val postgres = "9.4.1209"
   lazy val py4j = "0.10.4"
   lazy val scalaTest = "2.2.6"


### PR DESCRIPTION
This changes OSS dependency to our Spark fork. This dependency drags in netty 4.1.13.