### PR TITLE
DSP-14176 publishing extra jars for Spark Job Server

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,8 +12,6 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 
 addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.3.5")
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-
 addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.3")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")


### PR DESCRIPTION
Extras, python and api are published by:

export MVN_PUBLISH_REPO=abc
export MVN_PUBLISH_URL=xyz
sbt publish

Most of the dependencies from poms are removed since users should
use dse-spark-dependencies.

Main assembly artifact is published as it used be - no changes here.