### PR TITLE
DSP-14970 migrate to H2 sqlDao (from deprecated FileDao)

### DIFF
--- a/job-server/config/dse.conf
+++ b/job-server/config/dse.conf
@@ -14,13 +14,6 @@ spark {
 
   jobserver {
     port = 8090
-    jar-store-rootdir = /tmp/jobserver/jars
-
-    jobdao = spark.jobserver.io.JobFileDAO
-
-    filedao {
-      rootdir = /tmp/spark-job-server/filedao/data
-    }
   }
 
   # predefined Spark contexts


### PR DESCRIPTION
DAOs are used to store meta data about jars, contexts and jobs. So far
we used FileDao that is now deprecated and will be removed in the
future.
This configuration change makes Spark Jobserver use default dao which is
H2 SqlDao. It is also durable (stores data on disk).