### PR TITLE
DSP-15163 use dse script to start context in separate jvm

### DIFF
--- a/bin/manager_start.sh
+++ b/bin/manager_start.sh
@@ -14,7 +14,7 @@ get_abs_script_path
 . $appdir/setenv.sh
 
 # Override logging options to provide per-context logging
-LOGGING_OPTS="-Dlog4j.configuration=file:$appdir/log4j-server.properties
+LOGGING_OPTS="$LOGGING_OPTS_FILE
               -DLOG_DIR=$1"
 
 GC_OPTS="-XX:+UseConcMarkSweepGC

--- a/bin/manager_start.sh
+++ b/bin/manager_start.sh
@@ -40,5 +40,5 @@ else
   $appdir/spark-job-server.jar $1 $2 $conffile'
 fi
 
-eval $cmd > /dev/null 2>&1 &
+eval $cmd > /dev/null 2>&1
 # exec java -cp $CLASSPATH $GC_OPTS $JAVA_OPTS $LOGGING_OPTS $CONFIG_OVERRIDES $MAIN $1 $2 $conffile 2>&1 &

--- a/bin/setenv.sh
+++ b/bin/setenv.sh
@@ -43,8 +43,10 @@ if [ -z "$LOG_DIR" ]; then
 fi
 mkdir -p $LOG_DIR
 
-LOGGING_OPTS="-Dlogback.configurationFile=file:$appdir/logback-server.xml
-              -DLOG_DIR=$LOG_DIR"
+# used in server_start and in manager_start
+LOGGING_OPTS_FILE="-Dlogback.configurationFile=file:$appdir/logback-server.xml"
+
+LOGGING_OPTS="$LOGGING_OPTS_FILE -DLOG_DIR=$LOG_DIR"
 
 # For Mesos
 CONFIG_OVERRIDES="-Dspark.executor.uri=$SPARK_EXECUTOR_URI "

--- a/job-server/config/dse.conf
+++ b/job-server/config/dse.conf
@@ -56,3 +56,8 @@ spark {
 
 # Note that you can use this file to define settings not only for job server,
 # but for your Spark jobs as well.  Spark job configuration merges with this configuration file as defaults.
+
+
+deploy {
+  manager-start-cmd = "dse spark-jobserver context-per-jvm-managed-start"
+}


### PR DESCRIPTION
Dse script is used for manager-start-cmd because it is easily reachable
by spark jobserver. Original value for manager-start-cmd is
./manager_start.sh which ends in file not found error. Providing full
path to config file would introduce unnecessary complexity.

Context-per-jvm share logging configuration with spark jobserver
instance. However logging dir is different, every context-per-jvm
instance have it's own logging directory.