### PR TITLE
DSP-15163 use dse script to start context in separate jvm

### DIFF
--- a/bin/manager_start.sh
+++ b/bin/manager_start.sh
@@ -13,6 +13,10 @@ get_abs_script_path
 
 . $appdir/setenv.sh
 
+# Override logging options to provide per-context logging
+LOGGING_OPTS="$LOGGING_OPTS_FILE
+              -DLOG_DIR=$5"
+
 GC_OPTS="-XX:+UseConcMarkSweepGC
          -verbose:gc -XX:+PrintGCTimeStamps
          -XX:MaxPermSize=512m
@@ -31,7 +35,6 @@ if [ $2 = "cluster" -a -z "$REMOTE_JOBSERVER_DIR" ]; then
     --files $appdir/log4j-cluster.properties,$conffile"
   JAR_FILE="$appdir/spark-job-server.jar"
   CONF_FILE=$(basename $conffile)
-  LOGGING_OPTS="-Dlog4j.configuration=log4j-cluster.properties"
 
 # use files in REMOTE_JOBSERVER_DIR
 elif [ $2 == "cluster" ]; then
@@ -40,13 +43,11 @@ elif [ $2 == "cluster" ]; then
     --conf spark.yarn.submit.waitAppCompletion=false"
   JAR_FILE="$REMOTE_JOBSERVER_DIR/spark-job-server.jar"
   CONF_FILE="$REMOTE_JOBSERVER_DIR/$(basename $conffile)"
-  LOGGING_OPTS="-Dlog4j.configuration=$REMOTE_JOBSERVER_DIR/log4j-cluster.properties"
 
 # client mode, use files from app dir
 else
   JAR_FILE="$appdir/spark-job-server.jar"
   CONF_FILE="$conffile"
-  LOGGING_OPTS="-Dlog4j.configuration=file:$appdir/log4j-server.properties -DLOG_DIR=$5"
   GC_OPTS="$GC_OPTS -Xloggc:$5/gc.out"
 fi
 

--- a/bin/setenv.sh
+++ b/bin/setenv.sh
@@ -53,8 +53,10 @@ if [ -z "$LOG_DIR" ]; then
 fi
 mkdir -p $LOG_DIR
 
-LOGGING_OPTS="-Dlogback.configurationFile=file:$appdir/logback-server.xml
-              -DLOG_DIR=$LOG_DIR"
+# used in server_start and in manager_start
+LOGGING_OPTS_FILE="-Dlogback.configurationFile=file:$appdir/logback-server.xml"
+
+LOGGING_OPTS="$LOGGING_OPTS_FILE -DLOG_DIR=$LOG_DIR"
 
 if [ -z "$JMX_PORT" ]; then
     JMX_PORT=9999

--- a/job-server/config/dse.conf
+++ b/job-server/config/dse.conf
@@ -49,3 +49,8 @@ spark {
 
 # Note that you can use this file to define settings not only for job server,
 # but for your Spark jobs as well.  Spark job configuration merges with this configuration file as defaults.
+
+
+deploy {
+  manager-start-cmd = "dse spark-jobserver context-per-jvm-managed-start"
+}

--- a/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/AkkaClusterSupervisorActor.scala
@@ -248,7 +248,7 @@ class AkkaClusterSupervisorActor(daoActor: ActorRef, dataManagerActor: ActorRef)
     }
 
     val contextLogger = LoggerFactory.getLogger("manager_start")
-    val process = Process(managerStartCommand, managerArgs)
+    val process = Process(managerStartCommand.split(" ") ++ managerArgs)
     process.run(ProcessLogger(out => contextLogger.info(out), err => contextLogger.warn(err)))
 
     contextInitInfos(contextActorName) = (mergedContextConfig, isAdHoc, successFunc, failureFunc)


### PR DESCRIPTION
Dse script is used for manager-start-cmd because it is easily reachable
by spark jobserver. Original value for manager-start-cmd is
./manager_start.sh which ends in file not found error. Providing full
path to config file would introduce unnecessary complexity.

Context-per-jvm share logging configuration with spark jobserver
instance. However logging dir is different, every context-per-jvm
instance have it's own logging directory.