### PR TITLE
DSP-22557 Use shiro 1.8.0 to remove CVE-2021-41303 (dse-2.4)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -321,7 +321,23 @@ lazy val publishSettings = Seq(
         case _ => node
       }
     }).transform(node).head
-  }
+  },
+  publishConfiguration := new PublishConfiguration(
+    publishConfiguration.value.ivyFile,
+    publishConfiguration.value.resolverName,
+    publishConfiguration.value.artifacts,
+    publishConfiguration.value.checksums,
+    publishConfiguration.value.logging,
+    true
+  ),
+  publishLocalConfiguration := new PublishConfiguration(
+    publishLocalConfiguration.value.ivyFile,
+    publishLocalConfiguration.value.resolverName,
+    publishLocalConfiguration.value.artifacts,
+    publishLocalConfiguration.value.checksums,
+    publishLocalConfiguration.value.logging,
+    true
+  )
 )
 
 // This is here so we can easily switch back to Logback when Spark fixes its log4j dependency.

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -22,7 +22,7 @@ object Versions {
   lazy val py4j = "0.10.7"
   lazy val scalaTest = "2.2.6"
   lazy val scalatic = "2.2.6"
-  lazy val shiro = "1.7.1"
+  lazy val shiro = "1.8.0"
   lazy val slick = "3.1.1"
   lazy val spray = "1.3.3"
   lazy val sprayJson = "1.3.5"


### PR DESCRIPTION
Update `shiro` from `1.7.1` to `1.8.0` due to CVE-2021-41303

---

https://jenkins-dse.build.dsinternal.org/view/DSE/job/DSE_Spark_Jobserver/23/
https://jenkins-dse.build.dsinternal.org/view/DSE/job/DSE_Spark_Jobserver_Extras/10/