### PR TITLE
Dsp 22579 dse 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -288,7 +288,23 @@ lazy val publishSettings = Seq(
         case _ => node
       }
     }).transform(node).head
-  }
+  },
+  publishConfiguration := new PublishConfiguration(
+    publishConfiguration.value.ivyFile,
+    publishConfiguration.value.resolverName,
+    publishConfiguration.value.artifacts,
+    publishConfiguration.value.checksums,
+    publishConfiguration.value.logging,
+    true
+  ),
+  publishLocalConfiguration := new PublishConfiguration(
+    publishLocalConfiguration.value.ivyFile,
+    publishLocalConfiguration.value.resolverName,
+    publishLocalConfiguration.value.artifacts,
+    publishLocalConfiguration.value.checksums,
+    publishLocalConfiguration.value.logging,
+    true
+  )
 )
 
 // This is here so we can easily switch back to Logback when Spark fixes its log4j dependency.

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -19,7 +19,7 @@ object Versions {
   lazy val logback = "1.0.7"
   lazy val scalaTest = "2.2.6"
   lazy val scalatic = "2.2.6"
-  lazy val shiro = "1.7.0"
+  lazy val shiro = "1.8.0"
   lazy val cassandraUnit = "2.2.2.1"
   lazy val py4j = "0.10.3"
 }


### PR DESCRIPTION
This PR is for DSP-22579, which is to bump shiro version to 1.8.0.
It is cherry-picking commits from #42 to `dse-2` branch used by DSE 5.1.x line.

---

https://jenkins-dse.build.dsinternal.org/view/DSE/job/DSE_Spark_Jobserver/30/
https://jenkins-dse.build.dsinternal.org/view/DSE/job/DSE_Spark_Jobserver_Extras/12/