### PR TITLE
DSP-22894. Remove postgresql and mysql support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -958,7 +958,7 @@ Spark Jobserver programmatically.
 ## Contribution and Development
 Contributions via Github Pull Request are welcome. Please start by taking a look at the [contribution guidelines](doc/contribution-guidelines.md) and check the TODO for some contribution ideas.
 
-- You mean need `export TERM=xterm-color` for `sbt` to work
+- You may need `export TERM=xterm-color` for `sbt` to work
 - If you need to build with a specific scala version use ++x.xx.x followed by the regular command,
 for instance: `sbt ++2.11.6 job-server/compile`
 - From the "master" project, please run "test" to ensure nothing is broken.

--- a/README.md
+++ b/README.md
@@ -958,6 +958,7 @@ Spark Jobserver programmatically.
 ## Contribution and Development
 Contributions via Github Pull Request are welcome. Please start by taking a look at the [contribution guidelines](doc/contribution-guidelines.md) and check the TODO for some contribution ideas.
 
+- You mean need `export TERM=xterm-color` for `sbt` to work
 - If you need to build with a specific scala version use ++x.xx.x followed by the regular command,
 for instance: `sbt ++2.11.6 job-server/compile`
 - From the "master" project, please run "test" to ensure nothing is broken.

--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,7 @@ lazy val jobServerPythonSettings = revolverSettings ++ Assembly.settings ++ publ
 )
 
 lazy val jobServerTestJarSettings = Seq(
-  libraryDependencies ++= sparkDeps ++ apiDeps,
+  libraryDependencies ++= sparkDeps ++ apiDeps ++ slickTestDeps,
   description := "Test jar for Spark Job Server",
   exportJars := true // use the jar instead of target/classes
 )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,10 +55,13 @@ object Dependencies {
   lazy val slickDeps = Seq(
     "com.typesafe.slick" %% "slick" % slick,
     "com.h2database" % "h2" % h2,
-    "org.postgresql" % "postgresql" % postgres,
-    "mysql" % "mysql-connector-java" % mysql,
     "commons-dbcp" % "commons-dbcp" % commons,
     "org.flywaydb" % "flyway-core" % flyway
+  )
+
+  lazy val slickTestDeps = Seq(
+    "org.postgresql" % "postgresql" % postgres,
+    "mysql" % "mysql-connector-java" % mysql
   )
 
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+export TERM=xterm-color
+
 echo "Running sbt test and coverage report"
 sbt clean coverage testPython test coverageReport
 echo "Running pep8 over .py files"


### PR DESCRIPTION
For DSE spark-jobserver H2 is default metadata database. Using external postgresql or mysql is not recommended and not tested.

Outdated postgresql jdbc driver bundled in spark-jobserver includes several CVEs that are fixed in 42.x line of the driver.

It is more secure to just remove the driver than
to update it and then keep it updated.

For exactly same reason we can remove mysql driver.