### PR TITLE
DSP-23019. Use shiro 1.10.1 to remove CVEs [dse-2.4]

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -22,7 +22,7 @@ object Versions {
   lazy val py4j = "0.10.7"
   lazy val scalaTest = "2.2.6"
   lazy val scalatic = "2.2.6"
-  lazy val shiro = "1.8.0"
+  lazy val shiro = "1.10.1"
   lazy val slick = "3.1.1"
   lazy val spray = "1.3.3"
   lazy val sprayJson = "1.3.5"


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40664 https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-32532