### PR TITLE
DSP-22562 stop excluding netty from package 

### DIFF
--- a/project/Assembly.scala
+++ b/project/Assembly.scala
@@ -12,7 +12,7 @@ object Assembly {
         "jetty", "jsp-api-2.0", "antlr", "avro", "slf4j-log4j", "log4j-1.2",
         "scala-actors", "commons-cli", "stax-api", "mockito", "lz4",
         // we rely on whatever version DSE has:
-        "spark", "netty", "dse-java-driver").exists(cp.data.getName.startsWith(_))
+        "spark", "dse-java-driver").exists(cp.data.getName.startsWith(_))
     } },
     // We don't need the Scala library, Spark already includes it
     assembleArtifact in assemblyPackageScala := false,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,14 +32,13 @@ object Dependencies {
   )
 
   lazy val sparkExtraDeps = Seq(
-    "org.apache.derby" % "derby" % derby % Provided excludeAll(excludeNettyIo, excludeQQ),
+    "org.apache.derby" % "derby" % derby % Provided excludeAll(excludeQQ),
     "org.apache.hadoop" % "hadoop-client" % hadoop % Provided
-      excludeAll(excludeNettyIo, excludeQQ, excludeAsm, excludeServlet),
-    "com.datastax.spark" %% "spark-mllib" % spark % Provided excludeAll(excludeNettyIo, excludeQQ),
-    "com.datastax.spark" %% "spark-sql" % spark % Provided excludeAll(excludeNettyIo, excludeQQ),
-    "com.datastax.spark" %% "spark-streaming" % spark % Provided excludeAll(excludeNettyIo, excludeQQ),
-    "com.datastax.spark" %% "spark-hive" % spark % Provided excludeAll(
-      excludeNettyIo, excludeQQ, excludeScalaTest
+      excludeAll(excludeQQ, excludeAsm, excludeServlet),
+    "com.datastax.spark" %% "spark-mllib" % spark % Provided excludeAll(excludeQQ),
+    "com.datastax.spark" %% "spark-sql" % spark % Provided excludeAll(excludeQQ),
+    "com.datastax.spark" %% "spark-streaming" % spark % Provided excludeAll(excludeQQ),
+    "com.datastax.spark" %% "spark-hive" % spark % Provided excludeAll(excludeQQ, excludeScalaTest
       )
   )
 
@@ -67,8 +66,7 @@ object Dependencies {
 
 
   lazy val cassandraDeps = Seq(
-    "com.datastax.dse" % "spark-connector" % cassandraConnector % Provided excludeAll(
-      excludeNettyIo, excludeQQ)
+    "com.datastax.dse" % "spark-connector" % cassandraConnector % Provided excludeAll(excludeQQ)
   )
 
   lazy val logbackDeps = Seq(

--- a/project/ExclusionRules.scala
+++ b/project/ExclusionRules.scala
@@ -5,7 +5,6 @@ object ExclusionRules {
   val excludeJackson = ExclusionRule(organization = "org.codehaus.jackson")
   val excludeScalaTest = ExclusionRule(organization = "org.scalatest")
   val excludeScala = ExclusionRule(organization = "org.scala-lang")
-  val excludeNettyIo = ExclusionRule(organization = "io.netty")
   val excludeAsm = ExclusionRule(organization = "asm")
   val excludeQQ = ExclusionRule(organization = "org.scalamacros")
   val excludeServlet = ExclusionRule(organization = "javax.servlet")


### PR DESCRIPTION
DSP-22562 stop excluding netty from package

Netty was being explicitly excluded so that DSE's version would be picked up
To fix https://github.com/advisories/GHSA-p979-4mfw-53vg DSE has removed it's dependency on Netty 3.9.9
spark-jobserver can't get rid of it's netty dependency entirely because no version of Akka has upgrade beyond netty 3.10.6
By packaging this version of netty into the spark-jobserver jar it can be removed as a direct dependency of DSE