### PR TITLE
DSP-24286 Updates JVM options for running in Java 11

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,5 +1,3 @@
--XX:MaxPermSize=512m
 -Xms256m
 -Xmx1g
 -XX:+CMSClassUnloadingEnabled
--XX:+UseConcMarkSweepGC

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -25,6 +25,6 @@ RUN sbt update
 COPY . .
 
 ENV SPARK_HOME /tmp/spark-2.2.0-bin-hadoop2.7
-ENV JAVA_OPTIONS "-Xmx1500m -XX:MaxPermSize=512m -Dakka.test.timefactor=3"
+ENV JAVA_OPTIONS "-Xmx1500m -Dakka.test.timefactor=3"
 
 CMD ["/usr/src/app/run_tests.sh"]

--- a/bin/manager_start.sh
+++ b/bin/manager_start.sh
@@ -17,9 +17,7 @@ get_abs_script_path
 LOGGING_OPTS="$LOGGING_OPTS_FILE
               -DLOG_DIR=$5"
 
-GC_OPTS="-XX:+UseConcMarkSweepGC
-         -verbose:gc -XX:+PrintGCTimeStamps
-         -XX:MaxPermSize=512m
+GC_OPTS="-verbose:gc
          -XX:+CMSClassUnloadingEnabled "
 
 JAVA_OPTS="-XX:MaxDirectMemorySize=$MAX_DIRECT_MEMORY
@@ -48,7 +46,7 @@ elif [ $2 == "cluster" ]; then
 else
   JAR_FILE="$appdir/spark-job-server.jar"
   CONF_FILE="$conffile"
-  GC_OPTS="$GC_OPTS -Xloggc:$5/gc.out"
+  GC_OPTS="$GC_OPTS -Xlog:gc:$5/gc.out"
 fi
 
 if [ -n "$6" ]; then

--- a/bin/server_start.sh
+++ b/bin/server_start.sh
@@ -20,9 +20,7 @@ get_abs_script_path
 
 . $appdir/setenv.sh
 
-GC_OPTS="-XX:+UseConcMarkSweepGC
-         -verbose:gc -XX:+PrintGCTimeStamps -Xloggc:$appdir/gc.out
-         -XX:MaxPermSize=512m
+GC_OPTS="-verbose:gc -Xlog:gc:$appdir/gc.out
          -XX:+CMSClassUnloadingEnabled "
 
 # To truly enable JMX in AWS and other containerized environments, also need to set

--- a/build.sbt
+++ b/build.sbt
@@ -234,7 +234,6 @@ lazy val rootSettings = Seq(
 lazy val revolverSettings = Seq(
   javaOptions in reStart += jobServerLogging,
   // Give job server a bit more PermGen since it does classloading
-  javaOptions in reStart += "-XX:MaxPermSize=256m",
   javaOptions in reStart += "-Djava.security.krb5.realm= -Djava.security.krb5.kdc=",
   // This lets us add Spark back to the classpath without assembly barfing
   fullClasspath in reStart := (fullClasspath in Compile).value,


### PR DESCRIPTION
Spark JobServer fails to start in Java 11 due to deprecated `-XX:+PrintGCTimeStamps` option.
Removes options that are no longer used and cause warnings:
 * `-XX:MaxPermSize`
 * `-XX:+UseConcMarkSweepGC`
 
Replaces `-Xloggc` by `-Xlog:gc` to remove Java 11 warning.