### PR TITLE
DSP-24286 Enables Spark JobServer in Java 11

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,3 +1,5 @@
+-XX:MaxPermSize=512m
 -Xms256m
 -Xmx1g
 -XX:+CMSClassUnloadingEnabled
+-XX:+UseConcMarkSweepGC

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -25,6 +25,6 @@ RUN sbt update
 COPY . .
 
 ENV SPARK_HOME /tmp/spark-2.2.0-bin-hadoop2.7
-ENV JAVA_OPTIONS "-Xmx1500m -Dakka.test.timefactor=3"
+ENV JAVA_OPTIONS "-Xmx1500m -XX:MaxPermSize=512m -Dakka.test.timefactor=3"
 
 CMD ["/usr/src/app/run_tests.sh"]

--- a/bin/manager_start.sh
+++ b/bin/manager_start.sh
@@ -17,7 +17,9 @@ get_abs_script_path
 LOGGING_OPTS="$LOGGING_OPTS_FILE
               -DLOG_DIR=$5"
 
-GC_OPTS="-verbose:gc
+GC_OPTS="-XX:+UseConcMarkSweepGC
+         -verbose:gc -XX:+PrintGCTimeStamps
+         -XX:MaxPermSize=512m
          -XX:+CMSClassUnloadingEnabled "
 
 JAVA_OPTS="-XX:MaxDirectMemorySize=$MAX_DIRECT_MEMORY
@@ -46,7 +48,7 @@ elif [ $2 == "cluster" ]; then
 else
   JAR_FILE="$appdir/spark-job-server.jar"
   CONF_FILE="$conffile"
-  GC_OPTS="$GC_OPTS -Xlog:gc:$5/gc.out"
+  GC_OPTS="$GC_OPTS -Xloggc:$5/gc.out"
 fi
 
 if [ -n "$6" ]; then

--- a/bin/manager_start.sh
+++ b/bin/manager_start.sh
@@ -17,7 +17,8 @@ get_abs_script_path
 LOGGING_OPTS="$LOGGING_OPTS_FILE
               -DLOG_DIR=$5"
 
-GC_OPTS="-XX:+UseConcMarkSweepGC
+GC_OPTS="-XX:+IgnoreUnrecognizedVMOptions
+         -XX:+UseConcMarkSweepGC
          -verbose:gc -XX:+PrintGCTimeStamps
          -XX:MaxPermSize=512m
          -XX:+CMSClassUnloadingEnabled "

--- a/bin/server_start.sh
+++ b/bin/server_start.sh
@@ -20,7 +20,8 @@ get_abs_script_path
 
 . $appdir/setenv.sh
 
-GC_OPTS="-XX:+UseConcMarkSweepGC
+GC_OPTS="-XX:+IgnoreUnrecognizedVMOptions
+         -XX:+UseConcMarkSweepGC
          -verbose:gc -XX:+PrintGCTimeStamps -Xloggc:$appdir/gc.out
          -XX:MaxPermSize=512m
          -XX:+CMSClassUnloadingEnabled "

--- a/bin/server_start.sh
+++ b/bin/server_start.sh
@@ -20,7 +20,9 @@ get_abs_script_path
 
 . $appdir/setenv.sh
 
-GC_OPTS="-verbose:gc -Xlog:gc:$appdir/gc.out
+GC_OPTS="-XX:+UseConcMarkSweepGC
+         -verbose:gc -XX:+PrintGCTimeStamps -Xloggc:$appdir/gc.out
+         -XX:MaxPermSize=512m
          -XX:+CMSClassUnloadingEnabled "
 
 # To truly enable JMX in AWS and other containerized environments, also need to set

--- a/build.sbt
+++ b/build.sbt
@@ -234,6 +234,7 @@ lazy val rootSettings = Seq(
 lazy val revolverSettings = Seq(
   javaOptions in reStart += jobServerLogging,
   // Give job server a bit more PermGen since it does classloading
+  javaOptions in reStart += "-XX:MaxPermSize=256m",
   javaOptions in reStart += "-Djava.security.krb5.realm= -Djava.security.krb5.kdc=",
   // This lets us add Spark back to the classpath without assembly barfing
   fullClasspath in reStart := (fullClasspath in Compile).value,


### PR DESCRIPTION
Previously, we removed JVM options that have been deprecated in Java 9+ (causing warnings in Java 11) and one option that didn't exist in Java 11.
The issue with that approach was that, those options are still valid in Java 8 which is the default for DSE 6.8 and at this stage we don't want break compatibility with DSE 6.8.

Instead, we simply add `-XX:+IgnoreUnrecognizedVMOptions` which prevents JVM to fail to start due to unrecognized options - hence allowing Spark JobServer to run in both Java 8 and Java 11 without any changes.

In case we need to make changes required for DSE 6.9 which is Java 11, we should consider a new branch similarly to what we have done for Spark.
