### PR TITLE
DSP-24857 Updates Apache Commons BeanUtils version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -84,7 +84,7 @@ object Dependencies {
 
   lazy val securityDeps = Seq(
     "org.apache.shiro" % "shiro-core" % shiro,
-    "commons-beanutils" % "commons-beanutils" % beanutils
+    "commons-beanutils" % "commons-beanutils" % beanutils exclude("commons-logging", "commons-logging")
   )
 
   lazy val serverDeps = apiDeps

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -91,8 +91,8 @@ object Dependencies {
   lazy val apiDeps = sparkDeps ++ miscDeps :+ typeSafeConfigDeps :+ scalaTestDep
 
   val repos = Seq(
-    "datastax-release" at "https://repo.sjc.dsinternal.org/artifactory/datastax-releases-local",
-    "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/",
+    "datastax-release" at "https://repo.aws.dsinternal.org/artifactory/datastax-releases-local",
+    "Typesafe Repo" at "https://repo.typesafe.com/typesafe/releases/",
     "sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/",
     "spray repo" at "http://repo.spray.io"
   )

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -28,5 +28,5 @@ object Versions {
   lazy val sprayJson = "1.3.5"
   lazy val typeSafeConfig = if (isJavaAtLeast("1.8")) "1.3.0" else "1.2.1"
   lazy val cassandraConnector = "6.0.9"
-  lazy val beanutils = "1.9.4"
+  lazy val beanutils = "1.11.0"
 }


### PR DESCRIPTION
Updates Apache Commons BeanUtils to latest 1.11.0 version to address CVE-2025-48734.